### PR TITLE
dt traversed length should be truncated to maxDet

### DIFF
--- a/PythonAPI/pycocotools/ext.cpp
+++ b/PythonAPI/pycocotools/ext.cpp
@@ -540,7 +540,7 @@ cpp_compute_iou(std::vector<int> imgIds,
       for (size_t i = 0; i < G; i++) {
         iscrowd[i] = gtsm->iscrowd[i];
       }
-      int m = D;
+      int m = std::min(D,(size_t)maxDet);
       int n = G;
       if(m==0 || n==0) {
         list[k] = py::array_t<double>();
@@ -576,7 +576,7 @@ cpp_compute_iou(std::vector<int> imgIds,
       for (size_t i = 0; i < G; i++) {
         iscrowd[i] = gtsm->iscrowd[i];
       }
-      int m = D;
+      int m = std::min(D,(size_t)maxDet);
       int n = G;
       if(m==0 || n==0) {
         list[k] = py::array_t<double>();


### PR DESCRIPTION
The Python implementation truncates the `dt` list to `maxDet` length at most : 
https://github.com/NVIDIA/cocoapi/blob/nvidia/master/PythonAPI/pycocotools/cocoeval.py#L188-L189

And the C version matches this when preparing data to be processed by `cpp_compute_iou` , since it only copies `min(D, madDet)` elements:
https://github.com/NVIDIA/cocoapi/blob/nvidia/master/PythonAPI/pycocotools/ext.cpp#L531 and
https://github.com/NVIDIA/cocoapi/blob/nvidia/master/PythonAPI/pycocotools/ext.cpp#L567

However, later on `D` is used as the number of `dt` elements to be considered, both for ‘bbox’, and ‘segm’. This may result in using out-of-bound access that can consume bogus data and/or cause a segmentation fault.
Current fix adjusts the length of `dt` used for computation to be `min(D,maxDet)` rather than `D` originally.
