### PR TITLE
Avoid assertion error due to creation of pointer to first element of empty vector

### DIFF
--- a/PythonAPI/pycocotools/ext.cpp
+++ b/PythonAPI/pycocotools/ext.cpp
@@ -112,7 +112,7 @@ cpp_evaluate(int useCats,
         auto gtsm = &gts_map[key(imgId,catId)];
         auto dtsm = &dts_map[key(imgId,catId)];
 
-        if((gtsm->id.size()==0) || (dtsm->id.size()==0)) {
+        if((gtsm->id.size()==0) && (dtsm->id.size()==0)) {
           continue;
         }
     
@@ -136,11 +136,11 @@ cpp_evaluate(int useCats,
         dtMatches_list.push_back(std::vector<double>(T*D));
         dtScores_list.push_back(std::vector<double>(D));
         // pointers
-        auto gtIg = &gtIgnore_list.back()[0];
-        auto dtIg = &dtIgnore_list.back()[0];
-        auto dtm = &dtMatches_list.back()[0];
-        auto dtScores = &dtScores_list.back()[0];
-        auto ious = &ious_map[key(imgId,catId)][0];
+	auto gtIg = (G==0) ? nullptr : &gtIgnore_list.back()[0];
+        auto dtIg = (D==0) ? nullptr : &dtIgnore_list.back()[0];
+        auto dtm = (D==0) ? nullptr: &dtMatches_list.back()[0];
+        auto dtScores = (D==0) ? nullptr : &dtScores_list.back()[0];
+        auto ious = (ious_map[key(imgId, catId)].size() == 0) ? nullptr : &ious_map[key(imgId,catId)][0];
         // set ignores
         for (int g = 0; g < G; g++) {
           double area = gtsm->area[g];

--- a/PythonAPI/pycocotools/ext.cpp
+++ b/PythonAPI/pycocotools/ext.cpp
@@ -112,7 +112,7 @@ cpp_evaluate(int useCats,
         auto gtsm = &gts_map[key(imgId,catId)];
         auto dtsm = &dts_map[key(imgId,catId)];
 
-        if((gtsm->id.size()==0) && (dtsm->id.size()==0)) {
+        if((gtsm->id.size()==0) || (dtsm->id.size()==0)) {
           continue;
         }
     


### PR DESCRIPTION
Hello,

While running the NVIDIA implementation of the MLPerf v0.6 SSD benchmark, in a RHEL UBI8 based container, I get the following assertion error during the first evaluation step:

`
...
/usr/include/c++/8/bits/stl_vector.h:932: std::vector<_Tp, _Alloc>::reference std::vector<_Tp, _Alloc>::operator[](std::vector<_Tp, _Alloc>::size_type) [with _Tp = long int; _Alloc = std::allocator<long int>; std::vector<_Tp, _Alloc>::reference = long int&; std::vector<_Tp, _Alloc>::size_type = long unsigned int]: Assertion '__builtin_expect(__n < this->size(), true)' failed
...
`

I was able to narrow down the error to be occurring in the C++ extension of the cocoapi on lines  139...142 of ext.cpp
```
auto gtIg = &gtIgnore_list.back()[0];
...
auto dtScores = &dtScores_list.back()[0];
```

Which is undefined behaviour when the vectors are empty, which occurs when `gtsm->id.size()==0` or `(dtsm->id.size()==0)`.

It's possible that my suggested fix causes other problems. Please let me know if so. It seems to make the benchmark run as expected.