### PR TITLE
Replace deprecated numpy.distutils

### DIFF
--- a/PythonAPI/setup.py
+++ b/PythonAPI/setup.py
@@ -1,26 +1,23 @@
+from os.path import abspath, join
 from setuptools import setup, Extension
 import numpy as np
-from numpy.distutils.misc_util import get_info
 
 # To compile and install locally run "python setup.py build_ext --inplace"
 # To install library to Python site-packages run "python setup.py build_ext install"
-
-library_dirs = []
-library_dirs += get_info('npymath')['library_dirs']
 
 ext_modules = [
     Extension(
         name='pycocotools._mask',
         sources=['../common/maskApi.c', 'pycocotools/_mask.pyx'],
         extra_compile_args=['-Wno-cpp', '-Wno-unused-function', '-std=c99'],
-        include_dirs = [np.get_include(), '../common'],
+        include_dirs=[np.get_include(), '../common'],
     ),
     Extension(
         name='ext',
         sources=['pycocotools/ext.cpp', 'pycocotools/simdjson.cpp'],
         extra_compile_args=['-O3', '-Wall', '-shared', '-fopenmp', '-std=c++17', '-fPIC'],
-        include_dirs = [np.get_include(), 'pycocotools'],
-        library_dirs=library_dirs,
+        include_dirs=[np.get_include(), 'pycocotools'],
+        library_dirs=[abspath(join(np.get_include(), '..', 'lib'))],
         libraries=['npymath', 'gomp']
     )
 ]
@@ -28,12 +25,12 @@ ext_modules = [
 setup(
     name='pycocotools',
     packages=['pycocotools'],
-    package_dir = {'pycocotools': 'pycocotools'},
+    package_dir={'pycocotools': 'pycocotools'},
     install_requires=[
         'setuptools>=18.0',
         'cython>=0.27.3',
         'matplotlib>=2.1.0',
     ],
     version='2.0+nv0.8.0',
-    ext_modules= ext_modules
+    ext_modules=ext_modules
 )


### PR DESCRIPTION
`numpy.distutils`, which is used in `setup.py` in the PythonAPI, was deprecated in NumPy 1.23.0 and removed in NumPy for Python >= 3.12 [1]. In this example [2] from the NumPy documentation, the path of `library_dirs` is set relative to NumPy's include directory via `os.path.abspath(os.path.join(np.get_include(), '..', 'libs'))`. This should ensure that cocoapi remains installable for newer versions of NumPy and Python.

[1] https://numpy.org/devdocs/release/1.23.0-notes.html#deprecations
[2] https://numpy.org/doc/1.25/reference/random/examples/cython/setup.py.html