### PR TITLE
[Python 3.12] Fixes setup

### DIFF
--- a/PythonAPI/setup.py
+++ b/PythonAPI/setup.py
@@ -1,9 +1,13 @@
-from os.path import abspath, join
+from os.path import abspath, join, exists
 from setuptools import setup, Extension
+from sys import version_info
 import numpy as np
 
 # To compile and install locally run "python setup.py build_ext --inplace"
 # To install library to Python site-packages run "python setup.py build_ext install"
+
+if (version_info.major, version_info.minor) >= (3, 12) and not exists("pycocotools/_mask.c"):
+    open("pycocotools/_mask.c", "w").close()
 
 ext_modules = [
     Extension(


### PR DESCRIPTION
A `setuptools` module expects that the file `pycocotools/_mask.c` exists along with `pycocotools/_mask.pyx`. However, the original design of `cocoapi` does not presume the existence of `pycocotools/_mask.c`. The workaround is to create an empty `pycocotools/_mask.c` just to satisfy the requirement of `setuptools`.

Requires #18 